### PR TITLE
Changed customer size quiz to a typeform.

### DIFF
--- a/app/assets/stylesheets/pages/_customer_data_new.scss
+++ b/app/assets/stylesheets/pages/_customer_data_new.scss
@@ -1,39 +1,39 @@
-.form-container {
-  background-color: white;
-  width: 700px;
-  margin: 0 auto;
-  z-index: 1000;
-  position: absolute;
-  top: 0;
-  transform: translate(20px, 20px);
-  padding: 20px;
-}
+// .form-container {
+//   background-color: white;
+//   width: 700px;
+//   margin: 0 auto;
+//   z-index: 1000;
+//   position: absolute;
+//   top: 0;
+//   transform: translate(20px, 20px);
+//   padding: 20px;
+// }
 
-.card-transformation {
-  height: 670px;
-  position: relative;
-  background-color: #FFEDD6;
-  width: 700px;
-  margin: 0 auto;
-}
+// .card-transformation {
+//   height: 670px;
+//   position: relative;
+//   background-color: #FFEDD6;
+//   width: 700px;
+//   margin: 0 auto;
+// }
 
-.submit-button {
-  justify-content: center;
-  align-items: center;
-  width: 200px;
-  height: 40px;
-  background: #CD7613;
-  border: 2px solid #CD7613;
-  box-sizing: border-box;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  border-radius: 8px;
+// .submit-button {
+//   justify-content: center;
+//   align-items: center;
+//   width: 200px;
+//   height: 40px;
+//   background: #CD7613;
+//   border: 2px solid #CD7613;
+//   box-sizing: border-box;
+//   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+//   border-radius: 8px;
 
-  &:hover {
-    filter: brightness(110%);
-    font-style: italic;
-  }
-}
+//   &:hover {
+//     filter: brightness(110%);
+//     font-style: italic;
+//   }
+// }
 
-.btn.btn-med:hover {
-  font-style: italic;
-}
+// .btn.btn-med:hover {
+//   font-style: italic;
+// }

--- a/app/views/customer_data/new.html.erb
+++ b/app/views/customer_data/new.html.erb
@@ -1,17 +1,11 @@
-<br>
-<div class="card-transformation">
-  <div class="form-container">
-      <h1>Enter your FitsMe details</h1>
-
-      <%= simple_form_for @customer_datum do |f| %>
-      <%= f.input :age, collection: 16..80, prompt: "Select your age" %>
-      <%= f.input :height, collection: 90..240, prompt: 'Select your height in cm' %>
-      <%= f.input :weight, collection: 36..140, prompt: 'Select your weight in kg' %>
-      <%= f.input :body_shape, as: :radio_buttons, collection: [['0', 'circle'], ['1', 'triangle'], ['2', 'rectangle']], label_method: :second, value_method: :first %>
-      <%= f.input :fit_preference, as: :radio_buttons, collection: [['0', 'tight'], ['1', 'medium'], ['2', 'loose']], label_method: :second, value_method: :first %>
-      <%= f.button :submit, "Submit", class: "submit-button" %>
-      <% end %>
-      <%= link_to 'Return home', root_path, class: "btn btn-med" %>
-      <br>
-    </div>
-  </div>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+  <title>FitsMe Customer Quiz</title>
+  <style type="text/css"> html{ margin: 0; height: 100%; overflow: hidden; } iframe{ position: absolute; left:0; right:0; bottom:0; top:0; border:0; } </style>
+</head>
+<body>
+  <iframe id="typeform-full" width="100%" height="100%" frameborder="0" allow="camera; microphone; autoplay; encrypted-media;" src="https://form.typeform.com/to/l6vQ7aZx?typeform-medium=embed-snippet"></iframe>
+  <script type="text/javascript" src="https://embed.typeform.com/embed.js"></script>
+</body>
+</html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
   </head>
 
   <body>
-    <%= render 'shared/navbarblue' %>
+    <%#= render 'shared/navbarblue' %>
     <%#= render 'shared/flashes' %>
 
     <%= yield %>


### PR DESCRIPTION
I created a Typeform for our customer quiz and added it to our app. At the moment I'm not sure how we're going to be able to capture the information received from the quiz in order to generate a size recommendation. I did some research and found that we could use a Typeform API which doesn't seem too difficult but I'd like to consult with a TA to see what they think our best option is.

Also, if you guys prefer a different background image that can easily be changed. I considered using a different picture for each question but I had some issues with it.

Also, I think using the same image could be good for "staying on brand" and our design not being all over the place.

<img width="706" alt="Screenshot 2021-02-28 at 21 01 52" src="https://user-images.githubusercontent.com/68465807/109431893-03160080-7a09-11eb-9698-14693d4c94df.png">